### PR TITLE
Add pulse agent script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # SkyLink360
 Aviation management platform with real-time flight tracking, passenger wellness features, and safety tools. Built with React, Express, TypeScript, and WebSocket.
+
+## Pulse Agent
+`pulse.py` provides simple 24/7 monitoring logic that polls Skyline360 APIs for a list of configured patients. It can be used in Codex apps by placing the file at your project root and executing it as a separate process.
+
+### Usage
+1. Install dependencies:
+   ```bash
+   pip install requests
+   ```
+2. Configure patient IDs and optional loop interval:
+   ```bash
+   export PULSE_PATIENTS="123,456"
+   export PULSE_INTERVAL=60
+   ```
+3. Run the agent:
+   ```bash
+   python pulse.py
+   ```
+The script runs continuously and sends alerts through the `sendAlert` action when any patient's vitals contain a `critical` flag.

--- a/pulse.py
+++ b/pulse.py
@@ -1,0 +1,52 @@
+import os
+import time
+import requests
+
+API_BASE = "https://skyline360.com/api"
+
+# List of patient IDs to monitor
+PATIENTS = os.getenv("PULSE_PATIENTS", "").split(",") if os.getenv("PULSE_PATIENTS") else []
+
+
+def get_compliance_status(user_id: str) -> dict:
+    """Fetch compliance status for a given user."""
+    resp = requests.get(f"{API_BASE}/compliance", params={"user_id": user_id}, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def check_vitals(patient_id: str) -> dict:
+    """Retrieve real-time vitals for a patient."""
+    resp = requests.get(f"{API_BASE}/vitals", params={"patient_id": patient_id}, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def send_alert(patient_id: str, alert_type: str, notes: str = "") -> dict:
+    """Send an alert to the ICU team for a critical condition."""
+    payload = {"patient_id": patient_id, "alert_type": alert_type, "notes": notes}
+    resp = requests.post(f"{API_BASE}/alerts", json=payload, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def monitor_patient(patient_id: str) -> None:
+    """Check patient vitals and dispatch alerts if necessary."""
+    vitals = check_vitals(patient_id)
+    if vitals.get("critical"):
+        send_alert(patient_id, "critical", "Vitals flagged critical by pulse agent")
+
+
+def run_loop(interval: int = 60) -> None:
+    """Run the monitoring loop continuously."""
+    if not PATIENTS:
+        raise ValueError("No patient IDs configured. Set PULSE_PATIENTS environment variable.")
+    while True:
+        for patient_id in PATIENTS:
+            monitor_patient(patient_id)
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    interval = int(os.getenv("PULSE_INTERVAL", "60"))
+    run_loop(interval)


### PR DESCRIPTION
## Summary
- add `pulse.py` script to continuously monitor patient vitals and send alerts
- document pulse agent setup and usage in README

## Testing
- `python -m py_compile pulse.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891dc35a3f8832c9fbb56cf7fc67661