### PR TITLE
Add schema version to gpt-actions configuration

### DIFF
--- a/openai/gpt-actions.json
+++ b/openai/gpt-actions.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "v1",
   "actions": [
     {
       "name": "getComplianceStatus",


### PR DESCRIPTION
## Summary
- add missing `schema_version` to gpt-actions definition for Skyline360

## Testing
- `jq '.' openai/gpt-actions.json`

------
https://chatgpt.com/codex/tasks/task_e_6891cffb273c832cadca6b801fd6c2e5