### PR TITLE
Add preview generator and sample preview

### DIFF
--- a/generatePreview.js
+++ b/generatePreview.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Generate a preview.html file for a given app.
+ * The preview includes the app's cover image so that
+ * services can display a quick visual reference.
+ *
+ * @param {{name: string, path: string}} app - Application details.
+ */
+function generatePreview(app) {
+  if (!app || !app.name || !app.path) {
+    throw new Error('An app object with name and path is required');
+  }
+
+  fs.writeFileSync(
+    path.join(app.path, 'preview.html'),
+    `<img src="assets/cover.png" style="width:100%;max-width:600px;" alt="${app.name} Cover"/>`
+  );
+}
+
+module.exports = { generatePreview };

--- a/preview.html
+++ b/preview.html
@@ -1,0 +1,1 @@
+<img src="assets/cover.png" style="width:100%;max-width:600px;" alt="SkyLine360 Cover"/>


### PR DESCRIPTION
## Summary
- add utility function to create a `preview.html` file that embeds the app's cover image
- generate a sample `preview.html` using the utility for SkyLine360

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689202a7cc9c832cb5c32f9d96487d3d