### PR TITLE
Fix error detection and regex in watcher

### DIFF
--- a/watcherAgent.js
+++ b/watcherAgent.js
@@ -15,8 +15,8 @@ async function processFile(filePath) {
   try {
     const content = await fs.promises.readFile(filePath, 'utf8');
 
-    if (content.includes('console.log("error') || content.includes('fixMe')) {
-      const fixedContent = content.replace(/console\.log\("error.*"\);?/g, '');
+    if (content.includes('console.log("error")') || content.includes('fixMe')) {
+      const fixedContent = content.replace(/console\.log\("error"\);?/g, '');
       await fs.promises.writeFile(filePath, fixedContent, 'utf8');
 
       broadcast(`✅ Auto-fixed issue in ${path.basename(filePath)}`);


### PR DESCRIPTION
## Summary
- fix console.log("error") detection logic in watcher agent
- simplify regex to properly remove offending log statements

## Testing
- `node watcherAgent.js` *(fails: Cannot find module 'chokidar')*
- `npm install chokidar --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689220fd39ec832ca11c6a17cd0c43ba