### PR TITLE
chore(watcher): add Node watcher and exclude from Deno lint

### DIFF
--- a/.deno.jsonc
+++ b/.deno.jsonc
@@ -1,0 +1,8 @@
+{
+  "lint": {
+    "files": {
+      "include": ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
+      "exclude": ["watcherAgent.js"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Node-based watcher that removes stray error logs and uses chokidar when available
- configure Deno linting to ignore the Node watcher
- add empty watched directory for future files

## Testing
- `deno lint` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6895639a473c832c85faee97fe9c9252